### PR TITLE
Add CI workflow for .NET build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Build.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - run: dotnet restore
+
+      - run: dotnet build --no-restore --configuration Release


### PR DESCRIPTION
## Summary

- Add GitHub Actions CI workflow (`.github/workflows/ci.yml`)
- Builds the solution on pushes to `main` and on pull requests
- Uses .NET SDK 10.0 matching `global.json`
- Includes NuGet package caching for faster builds

## Backlog Item

Resolves health check: **CI/CD Workflows** (Tier 2 — 2 points)

## Acceptance Criteria

- [x] `.github/workflows/` directory exists with at least one `.yml` file
- [ ] Workflow runs successfully on push/PR