### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Report a bug in SudokuSolver
+labels: bug
+---
+
+## Description
+
+A clear description of what the bug is.
+
+## Steps to Reproduce
+
+1. Run `dotnet run` with the following puzzle input:
+2. ...
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include console output if applicable.
+
+## Environment
+
+- OS: [e.g., Windows 11, macOS 14, Ubuntu 24.04]
+- .NET SDK version: [e.g., 10.0.103]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+about: Suggest an enhancement for SudokuSolver
+labels: enhancement
+---
+
+## Problem
+
+A clear description of the problem or limitation you're experiencing.
+
+## Proposed Solution
+
+Describe the feature or improvement you'd like to see.
+
+## Alternatives Considered
+
+Any alternative solutions or workarounds you've considered.
+
+## Additional Context
+
+Any other context, screenshots, or examples that help explain the request.


### PR DESCRIPTION
## Summary

- Add bug report template (`.github/ISSUE_TEMPLATE/bug_report.md`)
- Add feature request template (`.github/ISSUE_TEMPLATE/feature_request.md`)
- Templates include structured sections tailored to the SudokuSolver project

## Backlog Item

Resolves health check: **Issue Templates** (Tier 2 — 2 points)

## Acceptance Criteria

- [x] `.github/ISSUE_TEMPLATE/` directory exists with at least one file