### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | Yes       |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in SudokuSolver, please report it responsibly:
+
+1. **Do not** open a public GitHub issue
+2. Instead, use [GitHub's private vulnerability reporting](https://github.com/phmatray/SudokuSolver/security/advisories/new) to submit your report
+3. Include a description of the vulnerability, steps to reproduce, and any potential impact
+
+You can expect an initial response within 7 days. If the vulnerability is confirmed, a fix will be prioritized and released as soon as possible.


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` with vulnerability reporting instructions
- Directs reporters to GitHub's private vulnerability reporting feature
- Includes response timeline commitment

## Backlog Item

Resolves health check: **SECURITY.md** (Tier 3 — 1 point)

## Acceptance Criteria

- [x] SECURITY.md file exists in the repository root